### PR TITLE
Change to protobuf 3.1

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,1 @@
+git+git://github.com/david4096/schemas.git@protobuf31#egg=ga4gh_schemas

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,26 @@
-git+git://github.com/david4096/schemas.git@protobuf31#egg=ga4gh_schemas
+# This file allows our dependencies to be against specific versions
+# or git tags. Each line is similar to a requirements.txt line, 
+# except that when installing the dependencies, the constraints.txt
+# is converted into the `dependency_links` of the setuptools
+# packaging script. This allows us to maintain dependencies across
+# repositories.
+#
+# For example, during development we use the development version
+# of the schemas with the line:
+#
+# git+git://github.com/ga4gh/schemas.git@master#egg=ga4gh_schemas
+#
+# When one has proposed a schema modification, they can change this
+# constraint to point at the branch of their proposed change:
+#
+# git+git://github.com/david4096/schemas.git@protobuf31#egg=ga4gh_schemas
+#
+# Then, when the change has been accepted at the schemas repository
+# you can change this to point back at the master branch!
+#
+# When making a release, these constraints are changed to point at
+# the released dependency.
+#
+# ga4gh-schemas==0.1.0
+#
+git+git://github.com/david4096/schemas.git@pipfixes#egg=ga4gh_schemas

--- a/constraints.txt
+++ b/constraints.txt
@@ -23,4 +23,4 @@
 #
 # ga4gh-schemas==0.1.0
 #
-git+git://github.com/david4096/schemas.git@pipfixes#egg=ga4gh_schemas
+git+git://github.com/ga4gh/schemas.git@master#egg=ga4gh_schemas

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,7 @@
 mock
 nose
 pep8
-flake8
+flake8==3.2.0
 coverage
 humanize
 PyYAML

--- a/ga4gh/client/protocol.py
+++ b/ga4gh/client/protocol.py
@@ -100,7 +100,7 @@ def toJson(protoObject, indent=None):
     Serialises a protobuf object as json
     """
     # Using the internal method because this way we can reformat the JSON
-    js = json_format._MessageToJsonObject(protoObject, True)
+    js = json_format.MessageToDict(protoObject, True)
     return json.dumps(js, indent=indent)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@
 # These requirements are read directly into setup.py, so specify them
 # in the order that they should be in in setup.py
 ga4gh_common==0.0.5
-ga4gh_schemas==0.0.8
+ga4gh_schemas
 requests
-protobuf==3.0.0b3
+protobuf==3.1.0.post1

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,22 @@ with open("requirements.txt") as requirementsFile:
         pinnedVersion = line.split()[0]
         install_requires.append(pinnedVersion)
 
+dependency_links = []
+try:
+    with open("constraints.txt") as constraintsFile:
+        for line in constraintsFile:
+            line = line.strip()
+            if len(line) == 0:
+                continue
+            if line[0] == '#':
+                continue
+            if line.find('git') != -1:
+                dependency_links.append(line)
+except EnvironmentError:
+    print('No constraints file found, proceeding without '
+          'creating dependency links.')
+
 setup(
-    # END BOILERPLATE
     name="ga4gh_client",
     description="A client for the GA4GH reference server",
     packages=["ga4gh", "ga4gh.client"],
@@ -36,9 +50,9 @@ setup(
             'ga4gh_client=ga4gh.client.cli:client_main',
         ]
     },
-    # BEGIN BOILERPLATE
     long_description=long_description,
     install_requires=install_requires,
+    dependency_links=dependency_links,
     license='Apache License 2.0',
     include_package_data=True,
     zip_safe=True,

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,7 @@ try:
                 continue
             if line[0] == '#':
                 continue
-            if line.find('git') != -1:
-                dependency_links.append(line)
+            dependency_links.append(line)
 except EnvironmentError:
     print('No constraints file found, proceeding without '
           'creating dependency links.')


### PR DESCRIPTION
* Adds a `constraints.txt` for pointing to development or specific branches.
* Fix flake version.
* Replace private protobuf API calls.
* Add dependency_links to `setup.py`.

Close #36 by pinning flake version