### PR TITLE
Calls genotype list

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -23,4 +23,4 @@
 #
 # ga4gh-schemas==0.1.0
 #
-git+git://github.com/david4096/schemas.git@727_genotypes#egg=ga4gh_schemas
+git+git://github.com/ga4gh/schemas.git@master#egg=ga4gh_schemas

--- a/constraints.txt
+++ b/constraints.txt
@@ -23,4 +23,4 @@
 #
 # ga4gh-schemas==0.1.0
 #
-git+git://github.com/ga4gh/schemas.git@master#egg=ga4gh_schemas
+git+git://github.com/david4096/schemas.git@727_genotypes#egg=ga4gh_schemas

--- a/ga4gh/client/cli.py
+++ b/ga4gh/client/cli.py
@@ -481,7 +481,9 @@ class VariantFormatterMixin(object):
             print("\t", end="")
             for c in variant.calls:
                 print(
-                    c.call_set_id, c.genotype, c.genotype_likelihood, c.info,
+                    c.call_set_id,
+                    c.genotype.__str__().replace('\n', ''),
+                    c.genotype_likelihood, c.info,
                     c.phaseset, sep=":", end="\t")
             print()
 


### PR DESCRIPTION
Changes the print function to put the call information on a single line. Otherwise no putative changes. Will close #38 and goes with https://github.com/ga4gh/schemas/pull/735 https://github.com/ga4gh/server/pull/1512
