### PR TITLE
Improve documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -29,12 +29,5 @@ Client API
 
 .. todo:: Add overview documentation for the client API.
 
-.. autoclass:: ga4gh.client.client.HttpClient
-    :members: get_reference_set, get_reference,
-        get_dataset, get_variant_set, get_variant,
-        get_read_group_set, get_read_group,
-        get_bio_sample, get_individual,
-        search_datasets, search_reference_sets, search_references,
-        search_variant_sets, search_variants, search_read_group_sets,
-        search_reads, search_bio_samples, search_individuals
-
+.. automodule:: ga4gh.client.client
+    :members:

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,16 @@
+channels:
+- ioos
+dependencies:
+- protobuf=3.0.0=py27_0
+- openssl=1.0.2h=1
+- pip=8.1.2=py27_0
+- python=2.7.11=0
+- readline=6.2=2
+- setuptools=23.0.0=py27_0
+- six=1.10.0=py27_0
+- sqlite=3.13.0=0
+- tk=8.5.18=0
+- wheel=0.29.0=py27_0
+- zlib=1.2.8=3
+- pip:
+    - sphinx==1.5.1

--- a/ga4gh/client/client.py
+++ b/ga4gh/client/client.py
@@ -274,6 +274,7 @@ class AbstractClient(object):
     def get_rna_quantification_set(self, rna_quantification_set_id):
         """
         Returns the RnaQuantificationSet with the specified ID from the server.
+        
         :param str rna_quantification_set_id: The ID of the
             RnaQuantificationSet of interest.
         :return: The RnaQuantificationSet of interest.
@@ -286,6 +287,7 @@ class AbstractClient(object):
     def get_rna_quantification(self, rna_quantification_id):
         """
         Returns the RnaQuantification with the specified ID from the server.
+        
         :param str rna_quantification_id: The ID of the RnaQuantification of
             interest.
         :return: The RnaQuantification of interest.
@@ -298,6 +300,7 @@ class AbstractClient(object):
     def get_expression_level(self, expression_level_id):
         """
         Returns the ExpressionLevel with the specified ID from the server.
+        
         :param str expression_level_id: The ID of the ExpressionLevel of
             interest.
         :return: The ExpressionLevel of interest.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ ga4gh_common==0.0.5
 ga4gh_schemas
 requests
 protobuf==3.1.0.post1
+sphinx-argparse==0.1.15


### PR DESCRIPTION
The autogenerated documentation wasn't working properly. This reveals the docstrings and methods of the client library, although the links to the underlying types are dead.