### PR TITLE
Remove unset values from JSON

### DIFF
--- a/ga4gh/client/protocol.py
+++ b/ga4gh/client/protocol.py
@@ -100,7 +100,7 @@ def toJson(protoObject, indent=None):
     Serialises a protobuf object as json
     """
     # Using the internal method because this way we can reformat the JSON
-    js = json_format.MessageToDict(protoObject, True)
+    js = json_format.MessageToDict(protoObject, False)
     return json.dumps(js, indent=indent)
 
 


### PR DESCRIPTION
I believe this is the source of the client bug we have seen in the notebooks. The JSON serialization method was placing empty values in unset fields. This should allow the client to be future compatible for some fields. @kozbo 