### PR TITLE
Revert requirements to development cycle

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -23,5 +23,5 @@
 #
 # ga4gh-schemas==0.1.0
 #
-#git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
-#git+git://github.com/ga4gh/schemas.git@master#egg=ga4gh_schemas
+git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
+git+git://github.com/ga4gh/schemas.git@master#egg=ga4gh_schemas

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 #
 # These requirements are read directly into setup.py, so specify them
 # in the order that they should be in in setup.py
-ga4gh_common==0.0.5
-ga4gh_schemas==0.6.0a9.post2
+ga4gh_common
+ga4gh_schemas
 requests
 protobuf==3.1.0.post1


### PR DESCRIPTION
During development we remove the pinned schema requirement so that we can use the "floating" dependency of schemas/master. In the future we may choose to release from a branch as opposed to master, allowing us to leave the schemas and constraints intact for development purposes. @ejacox 