### PR TITLE
remove feature_id from ExpressionLevel

### DIFF
--- a/ga4gh/client/cli.py
+++ b/ga4gh/client/cli.py
@@ -754,16 +754,15 @@ class SearchExpressionLevelsRunner(AbstractSearchRunner):
     def __init__(self, args):
         super(SearchExpressionLevelsRunner, self).__init__(args)
         self._rnaQuantificationId = args.rnaQuantificationId
-        self._feature_ids = []
-        if len(args.featureIds) > 0:
-            self._feature_ids = args.featureIds.split(",")
+        self._names = []
+        if len(args.names) > 0:
+            self._names = args.names.split(",")
         self.threshold = args.threshold
 
     def run(self):
         iterator = self._client.search_expression_levels(
             rna_quantification_id=self._rnaQuantificationId,
-            feature_ids=self._feature_ids,
-            threshold=self.threshold)
+            names=self._names, threshold=self.threshold)
         self._output(iterator)
 
     def _textOutput(self, expressionObjs):
@@ -1082,11 +1081,11 @@ def addCallSetIdsArgument(parser):
             """)
 
 
-def addFeatureIdsArgument(parser):
+def addNamesArgument(parser):
     parser.add_argument(
-        "--featureIds", "-f", default=[],
-        help="""Return annotations on any of the feature IDs.
-            Pass in IDs as a comma separated list (no spaces).
+        "--names", "-n", default=[],
+        help="""Return matches on any of the listed names.
+            Pass in names as a comma separated list (no spaces).
             """)
 
 
@@ -1575,7 +1574,7 @@ def addExpressionLevelsSearchParser(subparsers):
     parser.set_defaults(runner=SearchExpressionLevelsRunner)
     addUrlArgument(parser)
     addPageSizeArgument(parser)
-    addFeatureIdsArgument(parser)
+    addNamesArgument(parser)
     parser.add_argument(
         "--rnaQuantificationId", default='',
         help="The RNA Quantification Id to search over")

--- a/ga4gh/client/client.py
+++ b/ga4gh/client/client.py
@@ -728,7 +728,7 @@ class AbstractClient(object):
             protocol.SearchRnaQuantificationsResponse)
 
     def search_expression_levels(
-            self, rna_quantification_id="", feature_ids=[], threshold=0.0):
+            self, rna_quantification_id="", names=[], threshold=0.0):
         """
         Returns an iterator over the ExpressionLevel objects from the server
 
@@ -740,7 +740,7 @@ class AbstractClient(object):
         """
         request = protocol.SearchExpressionLevelsRequest()
         request.rna_quantification_id = rna_quantification_id
-        request.feature_ids.extend(feature_ids)
+        request.names.extend(names)
         request.threshold = threshold
         request.page_size = pb.int(self._page_size)
         return self._run_search_request(


### PR DESCRIPTION
removes feature_id from ExpressionLevel and changes search query to filter by name instead
depends on:
ga4gh schema 818